### PR TITLE
Docfix: remove duplicate output of `print_supported_cpus`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,7 @@ if ci
     deploydocs(
         repo = "github.com/JuliaPerf/LIKWID.jl.git",
         devbranch = "main",
-        push_preview = false,
+        push_preview = true,
         # target = "site",
     )
 end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,5 +21,5 @@ using LIKWID
 
 ```@repl likwid
 LIKWID.print_supported_cpus()
-LIKWID.print_supported_cpus(; cprint=false) # hide
+Libc.flush_cstdio() # hide
 ```


### PR DESCRIPTION
See #15.

Closes #15.