### PR TITLE
add link from docs back to repo

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,7 @@
 # LIKWID - Like I Knew What I'm Doing
 
-LIKWID.jl is a Julia wrapper for the performance monitoring and benchmarking suite [LIKWID](https://github.com/RRZE-HPC/likwid).
+[LIKWID.jl](https://github.com/JuliaPerf/LIKWID.jl) is a Julia wrapper for the 
+performance monitoring and benchmarking suite [LIKWID](https://github.com/RRZE-HPC/likwid).
 
 ## Installation
 


### PR DESCRIPTION
This is often useful if people find the docs via some search engine and want to see the code.